### PR TITLE
Add stage mouseEnableStillEvents flag to disable emitting still mouse…

### DIFF
--- a/lib/src/core/scene_painter.dart
+++ b/lib/src/core/scene_painter.dart
@@ -142,8 +142,9 @@ class ScenePainter with EventDispatcherMixin {
   }
 
   void _detectMouseMove() {
-    // If there was no mouse move dispatch a still event this handles static mouse OVER/OUT for moving/hiding objects
-    if (!_mouseMoveInputDetected && _lastMouseX != -1000000) {
+    // If there was no mouse move, dispatch a still event.
+    // This handles static mouse OVER/OUT for moving/hiding objects.
+    if (_stage!.mouseEnableStillEvents && !_mouseMoveInputDetected && _lastMouseX != -1000000) {
       final input = MouseInputData(
         target: _stage,
         dispatcher: _stage!,

--- a/lib/src/display/stage.dart
+++ b/lib/src/display/stage.dart
@@ -31,6 +31,10 @@ class Stage extends GDisplayObjectContainer
 
   bool maskBounds = false;
 
+  /// This enable the system to track mouseover / mouseout when the mouse is not moving but objects on the scene are moving or appearing / disappearing
+  /// if you dont need this, you can turn it off to avoid streaming `MouseInputType.still` events to the stage.
+  bool mouseEnableStillEvents = true;
+
   @override
   String toString() {
     return '$runtimeType';


### PR DESCRIPTION
… events

By setting this flag to `false`, the system will stop emitting fake `still` mouse events used to detect mouseOver mouseOut when the mouse is not moving but objects on the scene are moving or appearing / disappearing.

This is an optimization to allow the user to opt out of this feature if there is no need for it.

This is a pretty safe change, the only place where we actually emit `MouseInputType.still` events is in `_detectMouseMove()` so once we turn this off, we effectively disable this feature.

Closes: #44